### PR TITLE
Added option to close GW2RPC when GW2 closes

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -3,3 +3,6 @@ APIKey =
 
 [Discord]
 UpdateFrequency = 10
+
+[AppSettings]
+CloseWithGw2 = False

--- a/gw2rpc/gw2rpc.py
+++ b/gw2rpc/gw2rpc.py
@@ -138,6 +138,9 @@ class GW2RPC:
         if self.process:
             if self.process.is_running():
                 return
+            else
+                if config.close_with_gw2:
+                    shutdown()   
         for pid in psutil.pids():
             try:
                 p = psutil.Process(pid)

--- a/gw2rpc/gw2rpc.py
+++ b/gw2rpc/gw2rpc.py
@@ -138,9 +138,9 @@ class GW2RPC:
         if self.process:
             if self.process.is_running():
                 return
-            else
+            else:
                 if config.close_with_gw2:
-                    shutdown()   
+                    self.shutdown()
         for pid in psutil.pids():
             try:
                 p = psutil.Process(pid)

--- a/gw2rpc/settings.py
+++ b/gw2rpc/settings.py
@@ -8,11 +8,13 @@ class Config:
         if not os.path.exists("config.ini"):
             config["API"] = {"APIKey": ""}
             config["Discord"] = {"UpdateFrequency": 10}
+            config["CloseWithGw2"] = {"CloseWithGw2": True}
             with open("config.ini", "w") as cfile:
                 config.write(cfile)
         config.read("config.ini")
         self.api_key = config["API"]["APIKey"]
         self.update_frequency = config.getint("Discord", "UpdateFrequency")
+        self.close_with_gw2 = configgetboolean("CloseWithGw2", "CloseWithGw2")
 
 
 config = Config()

--- a/gw2rpc/settings.py
+++ b/gw2rpc/settings.py
@@ -14,7 +14,11 @@ class Config:
         config.read("config.ini")
         self.api_key = config["API"]["APIKey"]
         self.update_frequency = config.getint("Discord", "UpdateFrequency")
-        self.close_with_gw2 = config.getboolean("AppSettings", "CloseWithGw2", fallback=False)
+
+        try:
+            self.close_with_gw2 = config.getboolean("AppSettings", "CloseWithGw2", fallback=False)
+        except ValueError:
+            self.close_with_gw2 = False
 
 
 config = Config()

--- a/gw2rpc/settings.py
+++ b/gw2rpc/settings.py
@@ -14,7 +14,7 @@ class Config:
         config.read("config.ini")
         self.api_key = config["API"]["APIKey"]
         self.update_frequency = config.getint("Discord", "UpdateFrequency")
-        self.close_with_gw2 = configgetboolean("CloseWithGw2", "CloseWithGw2")
+        self.close_with_gw2 = config.getboolean("CloseWithGw2", "CloseWithGw2")
 
 
 config = Config()

--- a/gw2rpc/settings.py
+++ b/gw2rpc/settings.py
@@ -8,13 +8,13 @@ class Config:
         if not os.path.exists("config.ini"):
             config["API"] = {"APIKey": ""}
             config["Discord"] = {"UpdateFrequency": 10}
-            config["CloseWithGw2"] = {"CloseWithGw2": True}
+            config["AppSettings"] = {"CloseWithGw2": True}
             with open("config.ini", "w") as cfile:
                 config.write(cfile)
         config.read("config.ini")
         self.api_key = config["API"]["APIKey"]
         self.update_frequency = config.getint("Discord", "UpdateFrequency")
-        self.close_with_gw2 = config.getboolean("CloseWithGw2", "CloseWithGw2")
+        self.close_with_gw2 = config.getboolean("AppSettings", "CloseWithGw2", fallback=False)
 
 
 config = Config()


### PR DESCRIPTION
When the GW2 process is no longer active, it will automatically shutdown GW2RPC
Not tested yet as i currently have no access to GW2. Will do asap, just wanted to get PR up already since it should be a small change