### PR TITLE
Add support for multiple accounts by separating API keys with commas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ Features:
 * Display character and elite spec
 * Automatic update checking
 * Web based registry for maps
+* Supports multiple accounts
 
 Exe versions are made using Pyinstaller

--- a/gw2rpc/api.py
+++ b/gw2rpc/api.py
@@ -19,19 +19,20 @@ class GW2Api:
                 required_permissions = ["characters", "builds", "account"]
                 for p in required_permissions:
                     if p not in res["permissions"]:
+                        log.warning("API key missing required permission: {}".format(p))
                         return False
                 log.info("API key verified")
                 return True
             except APIError:
                 return False
 
-        def get_world():
+        def get_account_and_world():
             try:
                 res = self._call_api("account")
                 ep = "worlds/{}".format(res["world"])
-                return self._call_api(ep)["name"]
+                return res["name"], self._call_api(ep)["name"]
             except (APIError, KeyError):
-                return None
+                return None, None
 
         self.__session = requests.Session()
         self._base_url = "https://api.guildwars2.com/v2/"
@@ -46,9 +47,9 @@ class GW2Api:
                 self._authenticated = True
         self.__session.headers.update(self.__headers)
         if self._authenticated:
-            self.world = get_world()
+            self.account, self.world = get_account_and_world()
         else:
-            self.world = None
+            self.account, self.world = None, None
 
     def get_map_info(self, map_id):
         return self._call_api("maps/" + str(map_id))
@@ -73,4 +74,41 @@ class GW2Api:
         return r.json()
 
 
-api = GW2Api(config.api_key)
+class MultiApi:
+    def __init__(self, keys):
+        self._unauthenticated_client = GW2Api()
+        self._clients = [GW2Api(k) for k in keys]
+        self._clients = [c for c in self._clients if c._authenticated]
+        self._authenticated = len(self._clients) != 0
+        self._last_used_client = None
+        self.account, self.world = (self._clients[0].account, self._clients[0].world) if self._authenticated else (None, None)
+
+    def get_map_info(self, map_id):
+        return self._unauthenticated_client.get_map_info(map_id)
+
+    def get_character(self, name):
+        if self._last_used_client:
+            try:
+                return self._last_used_client.get_character(name)
+            except APIError:
+                pass
+        for client in self._clients:
+            try:
+                c = client.get_character(name)
+                self._last_used_client = client
+                self.account, self.world = client.account, client.world
+                return c
+            except APIError:
+                pass
+        # intentionally cause an error as no API key matches
+        return self._unauthenticated_client.get_character(name)
+
+    def get_guild(self, gid):
+        if self._last_used_client:
+            return self._last_used_client.get_guild(gid)
+        # intentionally cause an error as there should have been a character request first
+        return self._unauthenticated_client.get_guild(gid)
+
+
+
+api = MultiApi(config.api_keys)

--- a/gw2rpc/settings.py
+++ b/gw2rpc/settings.py
@@ -22,7 +22,7 @@ class Config:
             with open("config.ini", "w") as cfile:
                 config.write(cfile)
         config.read("config.ini")
-        self.api_key = config["API"]["APIKey"]
+        self.api_keys = [k for k in map(str.strip, config["API"]["APIKey"].split(',')) if k]
         self.update_frequency = config.getint("Discord", "UpdateFrequency")
         self.close_with_gw2 = set_boolean("Settings", "CloseWithGw2")
         self.display_tag = set_boolean("Settings", "DisplayGuildTag")


### PR DESCRIPTION
Also adds `account` to the `api` module, but nothing uses that yet.