### PR TITLE
Assume character select when GW2 is not connected to the server IP.

### DIFF
--- a/gw2rpc/gw2rpc.py
+++ b/gw2rpc/gw2rpc.py
@@ -213,7 +213,7 @@ class GW2RPC:
         }
 
     def get_activity(self):
-        data = self.game.get_mumble_data()
+        data = self.game.get_mumble_data(self.process)
         if not data:
             return None
         current_time = time.time()
@@ -299,6 +299,8 @@ class GW2RPC:
                 except GameNotRunningError:
                     #  TODO
                     if self.rpc.running:
+                        if self.rpc.last_pid:
+                            self.rpc.send_rich_presence(None, self.rpc.last_pid, True)
                         self.rpc.last_payload = {}
                         self.rpc.last_pid = None
                         self.rpc.last_update = time.time()

--- a/gw2rpc/mumble.py
+++ b/gw2rpc/mumble.py
@@ -1,6 +1,8 @@
 import ctypes
 import json
 import mmap
+import psutil
+import socket
 
 
 class MumbleLinkException(Exception):
@@ -25,7 +27,15 @@ class Link(ctypes.Structure):
         ("fCameraTop",      ctypes.c_float * 3),
         ("identity",        ctypes.c_wchar * 256),
         ("context_len",     ctypes.c_uint32),
-        ("context",         ctypes.c_uint32 * 64),
+        ("addressFamily",   ctypes.c_uint16), # contains sockaddr_in or sockaddr_in6
+        ("serverPort",      ctypes.c_uint16),
+        ("serverAddress",   ctypes.c_uint8 * 24),
+        ("mapId",           ctypes.c_uint32),
+        ("mapType",         ctypes.c_uint32),
+        ("shardId",         ctypes.c_uint32),
+        ("instance",        ctypes.c_uint32),
+        ("buildId",         ctypes.c_uint32),
+        ("context",         ctypes.c_uint8 * 208), # first 48 bytes are defined
         ("description",     ctypes.c_wchar * 2048)
     ]
 # yapf:enable QA ON
@@ -36,6 +46,7 @@ class MumbleData:
         self.memfile = mmap.mmap(-1, ctypes.sizeof(Link), "MumbleLink")
         self.last_character = None
         self.last_map_id = None
+        self.last_server_ip = None
 
     @staticmethod
     def Unpack(ctype, buf):
@@ -44,12 +55,31 @@ class MumbleData:
             ctypes.pointer(cstring), ctypes.POINTER(ctype)).contents
         return ctype_instance
 
-    def get_mumble_data(self):
+    def get_mumble_data(self, process=None):
         self.memfile.seek(0)
         data = self.memfile.read(ctypes.sizeof(Link))
         result = self.Unpack(Link, data)
+        if result.name != "Guild Wars 2":
+            return None
         if not result.identity:
             return None
+        if result.addressFamily == socket.AF_INET:
+            self.last_server_ip = socket.inet_ntop(socket.AF_INET, bytearray(result.serverAddress[0:4]))
+        elif result.addressFamily == socket.AF_INET6:
+            self.last_server_ip = socket.inet_ntop(socket.AF_INET6, bytearray(result.serverAddress[4:20]))
+        else:
+            self.last_server_ip = None
+        if process and self.last_server_ip:
+            try:
+                have_connection = False
+                for conn in process.connections():
+                    if conn.status == 'ESTABLISHED' and conn.raddr.ip == self.last_server_ip:
+                        have_connection = True
+                        break
+                if not have_connection:
+                    return None
+            except:
+                pass
         data = json.loads(result.identity)
         character = data["name"]
         map_id = data["map_id"]

--- a/gw2rpc/rpc.py
+++ b/gw2rpc/rpc.py
@@ -66,7 +66,7 @@ class DiscordRPC:
         log.debug(f'OP Code: {code}; Length: {length}\nResponse:\n{json.loads(data[8:].decode("utf-8"))}\n')
 
     def send_rich_presence(self, activity, pid, force=False):
-        if self.compare_payloads(activity, self.last_payload) and not force:
+        if not force and self.compare_payloads(activity, self.last_payload):
             return self.refresh()
         current_time = time.time()
         payload = {
@@ -79,7 +79,7 @@ class DiscordRPC:
         }
         self.send_data(1, payload)
         self.last_update = current_time
-        self.last_payload = activity
+        self.last_payload = activity or {}
         self.last_pid = pid
         self.loop.run_until_complete(self.read_output())
 


### PR DESCRIPTION
Send a null activity payload to Discord when disconnecting.

Don't look at MumbleLink data if it is not from Guild Wars 2.