### PR TITLE
Fix race condition on process iteration

### DIFF
--- a/gw2rpc/gw2rpc.py
+++ b/gw2rpc/gw2rpc.py
@@ -349,8 +349,8 @@ class GW2RPC:
                 else:
                     if config.close_with_gw2:
                         shutdown = True
-            for process in psutil.process_iter():
-                name = process.name()
+            for process in psutil.process_iter(attrs=['name']):
+                name = process.info['name']
                 if name in ("Gw2-64.exe", "Gw2.exe"):
                     self.process = process
                     return


### PR DESCRIPTION
So I ran this program at startup, and without ever running GW2 since boot the process crashed.

I believe it's due to the race condition created when running `process.name()`. There is a chance that the process no longer exists during the loop, and `process.name()` requires the process to exist to work. Therefore there is a slim chance of a crash here.

So this pull request uses the attributes parameter in the `process_iter` function in order to cache the name attribute ensuring this crash does not occur again.

The error I received is below:

```
2018-09-19 16:18:43,050:CRITICAL:root: GW2RPC has crashed
Traceback (most recent call last):
  File "site-packages\psutil\_pswindows.py", line 635, in wrapper
  File "site-packages\psutil\_pswindows.py", line 701, in exe
ProcessLookupError: [Errno 3] No such process

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "gw2rpc\gw2rpc.py", line 373, in main_loop
  File "gw2rpc\gw2rpc.py", line 353, in update_gw2_process
  File "site-packages\psutil\__init__.py", line 604, in name
  File "site-packages\psutil\_pswindows.py", line 635, in wrapper
  File "site-packages\psutil\_pswindows.py", line 687, in name
  File "site-packages\psutil\_pswindows.py", line 640, in wrapper
psutil._exceptions.NoSuchProcess: psutil.NoSuchProcess process no longer exists (pid=16932)
```